### PR TITLE
Initial Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# yannoff/docker-store
+
+Source repository for [yannoff](https://hub.docker.com/u/yannoff/ "Yannoff's DockerHub")'s docker images
+
+- [alpine](https://github.com/yannoff/docker-store/tree/alpine/master/alpine)
+- [mariadb](https://github.com/yannoff/docker-store/tree/mariadb/master/mariadb)

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -1,0 +1,51 @@
+# vim: ft=dockerfile
+#
+# Alpine Linux image for MariaDB, using original entrypoint script
+#
+# @package mariadb
+# @author  yannoff <https://github.com/yannoff>
+# @license MIT
+#
+
+FROM alpine:latest
+
+MAINTAINER Yannoff <https://github.com/yannoff>
+
+# Install mariadb server, 
+# Also install bash, pwgen and libs needed by entrypoint script at first run
+RUN \
+    apk --update --no-cache add \
+        mysql \
+        pwgen \
+        tzdata \
+        libssl1.0 \
+        libstdc++;
+
+# Fetch genuine entrypoint from mariadb official github repo, to be sure we have an up-to-date version
+RUN \
+    apk add curl; \
+    curl https://raw.githubusercontent.com/docker-library/mariadb/master/docker-entrypoint.sh -o /docker-entrypoint.sh; \
+    chmod +x /docker-entrypoint.sh; \
+    ln -s /docker-entrypoint.sh /usr/local/bin/; 
+
+# Create socket dir
+RUN \
+    mkdir /run/mysqld && chown mysql:mysql /run/mysqld;
+
+# Alternatives - MariaDB genuine entry point needs gosu & mysql
+# - su-exec for gosu
+# - mysql_embedded for mysql (so we don't need to install mysql-client)
+RUN \ 
+    apk add --no-cache bash su-exec; \
+    ln -s $(which su-exec) /sbin/gosu; \
+    ln -s /usr/bin/mysql_embedded /usr/bin/mysql
+
+# Purge
+RUN \
+    apk del curl; \
+    rm -rfv /var/cache/apk/
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "mysqld" ]
+VOLUME [ "/var/lib/mysql" ]
+EXPOSE 3306

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -1,0 +1,37 @@
+# yannoff/docker-store/mariadb
+
+An image based on latest Alpine Linux, with edge MariaDB server installed.
+
+This is the source repository for [yannoff/mariadb](https://hub.docker.com/r/yannoff/mariadb/ "yannoff/mariadb on DockerHub") image on [DockerHub](https://hub.docker.com/).
+
+This image supports the [exact same features](https://github.com/docker-library/docs/blob/master/mariadb/README.md "MariaDB Official image documentation") as the original MariaDB image (except for TokuDB plugin which is not supported yet by Alpine Linux).
+
+## Usage 
+
+Example use case:
+
+- `xxxx` as root (i.e admin) password for MariaDB.
+- `3307` as exposed port on host machine
+- `./data` as persistent data directory
+- `db` for the service name
+
+### Usage standalone
+
+
+```bash
+docker run --rm -d --name db -e MYSQL_ROOT_PASSWORD=xxxx -p "3306:3306" -v "$(PWD)/data":/var/lib/mysql yannoff/mariadb
+```
+
+### Usage in a stack
+
+```yaml
+#docker-compose.yml
+db:
+    image: yannoff/mariadb
+    environment:
+        MYSQL_ROOT_PASSWORD: xxxx
+    volumes:
+        - "./data:/var/lib/mysql"
+    ports:
+        - "3307:3306"
+```


### PR DESCRIPTION
- Install runtime & first-run mandatory packages
- Download entrypoint script from mariadb repo
- Use alternative binaries for gosu & mysql client