### PR TITLE
Fix broken container execution

### DIFF
--- a/mongodb/Dockerfile
+++ b/mongodb/Dockerfile
@@ -5,14 +5,14 @@
 # @license MIT
 #
 
-FROM alpine:latest
+FROM alpine:3.9
 
 MAINTAINER yannoff <https://github.com/yannoff>
 
 # Retrieve MongoDB's official entrypoint from github
 RUN \
     apk --no-cache add curl; \
-    curl https://raw.githubusercontent.com/docker-library/mongo/master/3.0/docker-entrypoint.sh -o usr/local/bin/docker-entrypoint.sh; \
+    curl https://raw.githubusercontent.com/docker-library/mongo/master/4.1/docker-entrypoint.sh -o usr/local/bin/docker-entrypoint.sh; \
     chmod +x usr/local/bin/docker-entrypoint.sh; \
     ln -s usr/local/bin/docker-entrypoint.sh /entrypoint.sh # backwards compat
 


### PR DESCRIPTION
Freeze alpine/mongodb entrypoint versions to avoid compatibility breaks:
- Alpine: 3.9
- MongoDB: 4.1